### PR TITLE
Adds support for AMD loading

### DIFF
--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -1,43 +1,58 @@
-var module = angular.module('FBAngular', []);
+(function(window) {
+   var createModule = function(angular) {
+      var module = angular.module('FBAngular', []);
 
-module.factory('Fullscreen', function () {
+      module.factory('Fullscreen', ['$document', function ($document) {
+         var document = $document[0];
 
-   return {
-      all: function() {
-         this.enable( document.documentElement );
-      },
-      enable: function(element) {
-         if(element.requestFullScreen) {
-            element.requestFullScreen();
-         } else if(element.mozRequestFullScreen) {
-            element.mozRequestFullScreen();
-         } else if(element.webkitRequestFullScreen) {
-            element.webkitRequestFullScreen();
-         }
-      },
-      cancel: function() {
+         return {
+            all: function() {
+               this.enable( document.documentElement );
+            },
+            enable: function(element) {
+               if(element.requestFullScreen) {
+                  element.requestFullScreen();
+               } else if(element.mozRequestFullScreen) {
+                  element.mozRequestFullScreen();
+               } else if(element.webkitRequestFullScreen) {
+                  element.webkitRequestFullScreen();
+               }
+            },
+            cancel: function() {
 
-         if(document.cancelFullScreen) {
-            document.cancelFullScreen();
-         } else if(document.mozCancelFullScreen) {
-            document.mozCancelFullScreen();
-         } else if(document.webkitCancelFullScreen) {
-            document.webkitCancelFullScreen();
-         }
-      },
-      isEnabled: function(){
-         var fullscreenElement = document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement;
-         return fullscreenElement;
-      }
-   }
-})
+               if(document.cancelFullScreen) {
+                  document.cancelFullScreen();
+               } else if(document.mozCancelFullScreen) {
+                  document.mozCancelFullScreen();
+               } else if(document.webkitCancelFullScreen) {
+                  document.webkitCancelFullScreen();
+               }
+            },
+            isEnabled: function(){
+               var fullscreenElement = document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement;
+               return fullscreenElement;
+            }
+         };
+      }]);
 
-module.directive('fullscreen', function(Fullscreen) {
-   return {
-      link : function ($scope, $element, $attrs) {
-         $element.on('click', function (ev) {
-            Fullscreen.enable(  document.getElementById( $attrs.id  ));
-         });
-      }
+      module.directive('fullscreen', ['Fullscreen', '$document', function(Fullscreen, $document) {
+         var document = $document[0];
+
+         return {
+            link : function ($scope, $element, $attrs) {
+               $element.on('click', function (ev) {
+                  Fullscreen.enable(  document.getElementById( $attrs.id  ));
+               });
+            }
+         };
+      }]);
+
+      return module;
    };
-});
+
+   if (typeof define === "function" && define.amd) {
+      define("FBAngular", ['angular'], function (angular) { return createModule(angular); } );
+   } else {
+      createModule(window.angular);
+   }
+})(window);


### PR DESCRIPTION
Allows the script to be loaded via AMD, e.g. require.js.

**Requirements for require.js:**

Add pathis for `FBAngular` and `angular` named modules to your config:

```
var require = {
  /* ... */
  paths: {
    'angular': 'path/to/angular',
    'FBAngular': 'path/to/angular-fullscreen'
  }
};
```

Add `FBAngular` to your module's dependencies:

```
define(['angular', 'FBAngular'], function(angular, fbAngularModule) {
  // Note: fbAngularModule is the angular module, but most likely isn't needed

  // Add 'FBAngular' as a dependency to your Angular app:
  var app = angular.module('myApp', ['FBAngular']);
});
```

Additional changes include:
- Use inline bracket notation to allow the file to be minified, see: http://docs.angularjs.org/tutorial/step_05#controller_a-note-on-minification
- Inject `$document` instead of using global `document` to improves testability
