### PR TITLE
Allow full-screening an element by watching a $scope property

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ HTML:
 <button ng-click="goFullscreen()">Enable/Disable fullscreen</button>
 ```
 
+## Alternative Approach
+You may pass in the name of a scope property to watch. When the property
+becomes truthy, the element will become full screen:
+
+Controller:
+```javascript
+function MainCtrl($scope) {
+    // Initially, do not go into full screen
+    $scope.isFullscreen = false;
+
+    $scope.toggleFullScreen = function() {
+        $scope.isFullscreen = !$scope.isFullscreen;
+    }
+}
+```
+
+HTML:
+```html
+<div fullscreen="isFullscreen">Lorem ipsum...</div>
+<button ng-click="toggleFullScreen()">Toggle Full Screen</button>
+```
+
 #### Available Methods
 
 Method | Details

--- a/demo/app.js
+++ b/demo/app.js
@@ -13,6 +13,12 @@ function MainCtrl($scope, Fullscreen) {
       // Set Fullscreen to a specific element (bad practice)
       // Fullscreen.enable( document.getElementById('img') )
 
-   }
+   };
+
+   $scope.isFullScreen = false;
+
+   $scope.goFullScreenViaWatcher = function() {
+      $scope.isFullScreen = !$scope.isFullScreen;
+   };
 
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,6 +30,11 @@
 			<img id="img1" src="imgs/P1030188.JPG" fullscreen />
 			<img id="img2" src="imgs/P1030296.JPG" fullscreen />
 
+			<hr />
+			<h3>Go FullScreen Via Watched Property</h3>
+			<img src="imgs/P1030296.JPG" fullscreen="isFullScreen" />
+			<button ng-click="goFullScreenViaWatcher()">Toggle FullScreen</button>
+
 			<p>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin non neque eget sem luctus rutrum. Vivamus vestibulum fermentum dolor, ac rhoncus nisi blandit ac. Vestibulum in ante quis eros cursus congue id in lorem. Maecenas ut odio vitae nibh fringilla sagittis. Mauris pharetra porttitor lorem et dignissim. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam vitae vehicula elit, sit amet cursus tellus. Integer eu tellus mauris.
 			Fusce eros leo, gravida et tellus consectetur, pharetra rutrum nisi. In dictum nunc ac eros dapibus convallis. Vestibulum vehicula venenatis justo, id malesuada mi tempor et. Nam mattis commodo rhoncus. Cras sed nunc consectetur elit auctor accumsan. Vestibulum congue lectus eu enim fringilla, ac cursus enim blandit. In sagittis fringilla elementum.

--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -40,6 +40,18 @@
 
          return {
             link : function ($scope, $element, $attrs) {
+               // Watch for changes on scope if model is provided
+               if ($attrs.fullscreen) {
+                  $scope.$watch($attrs.fullscreen, function(value) {
+                     var isEnabled = Fullscreen.isEnabled();
+                     if (value && !isEnabled) {
+                        Fullscreen.enable($element[0]);
+                     } else if (!value && isEnabled) {
+                        Fullscreen.cancel();
+                     }
+                  });
+               }
+
                $element.on('click', function (ev) {
                   Fullscreen.enable(  document.getElementById( $attrs.id  ));
                });


### PR DESCRIPTION
This allows any element to go into full-screen mode without having to use IDs. Simply toggle a property on the `$scope` and pass in the property's name to the directive.

This eliminates the need to rely on IDs, and eliminates the need for the "bad practice" approach described in the README.

Note: This pull request is dependent on https://github.com/fabiobiondi/angular-fullscreen/pull/1
