### PR TITLE
fixing bug that requires to click twice to make it full screen:

### DIFF
--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -44,14 +44,17 @@
                      var isEnabled = Fullscreen.isEnabled();
                      if (value && !isEnabled) {
                         Fullscreen.enable($element[0]);
+                        $element.addClass('isInFullScreen');
                      } else if (!value && isEnabled) {
                         Fullscreen.cancel();
+                        $element.removeClass('isInFullScreen');
                      }
                   });
                   $element.on('fullscreenchange webkitfullscreenchange mozfullscreenchange', function(){
                      if(!Fullscreen.isEnabled()){
                         $scope.$evalAsync(function(){
                            $scope[$attrs.fullscreen] = false
+                           $element.removeClass('isInFullScreen');
                         })
                      }
                   })


### PR DESCRIPTION
see in example the "toggle FullScreen" button, after using it once, close the full screen mode and click it again
this pull request inculdes a lighter fix for  #10 pull request by not setting any value to the attribute it will work on click and by setting a value it will work using that value,
if anyone needs both it can just set the value using ng-click
