### PR TITLE
Ignore Demo folder in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,9 @@
     "html5",
     "angularjs"
   ],
+  "ignore": [
+    "demo"
+  ],
   "dependencies": {
     "angular": "~1.2.1"
   },


### PR DESCRIPTION
I think "demo" folder is useless in Bower package and ignoring this folder makes it lighter
