### PR TITLE
Coercing docElm into a boolean

### DIFF
--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -41,7 +41,7 @@
             },
             isSupported: function(){
                 var docElm = document.documentElement;
-                return docElm.requestFullScreen || docElm.mozRequestFullScreen || docElm.webkitRequestFullScreen || docElm.msRequestFullscreen;
+                return (docElm.requestFullScreen || docElm.mozRequestFullScreen || docElm.webkitRequestFullScreen || docElm.msRequestFullscreen) == null;
             }
          };
          


### PR DESCRIPTION
At least with Chrome, isSupported can return the requestFullScreen function instead of a boolean.

[This Plunker](http://plnkr.co/edit/YLYpfHrH8woIEsxlctun?p=preview) illustrates that currently isSupported returns a pointer to a (possibly vendor-prefixed) requestFullscreen function.

[This Plunker](http://plnkr.co/edit/1X8jys4Ev94Q7yKNa7jo?p=preview) illustrates that the change outputs only true/false values.
