### PR TITLE
Check also fullscreen enabled variable for iframes

### DIFF
--- a/src/angular-fullscreen.js
+++ b/src/angular-fullscreen.js
@@ -53,12 +53,15 @@
                return fullscreenElement ? true : false;
             },
             toggleAll: function(){
-                serviceInstance.isEnabled() ? serviceInstance.cancel() : serviceInstance.all();
+               serviceInstance.isEnabled() ? serviceInstance.cancel() : serviceInstance.all();
             },
             isSupported: function(){
-                var docElm = document.documentElement;
-                var requestFullscreen = docElm.requestFullScreen || docElm.mozRequestFullScreen || docElm.webkitRequestFullscreen || docElm.msRequestFullscreen;
-                return requestFullscreen ? true : false;
+               var docElm = document.documentElement;
+               var fullScreenEnabled = (docElm.requestFullScreen && document.fullscreenEnabled) ||
+                  (docElm.mozRequestFullScreen && document.mozFullScreenEnabled) ||
+                  (docElm.webkitRequestFullscreen && document.webkitFullscreenEnabled) ||
+                  (docElm.msRequestFullscreen && document.msFullscreenEnabled);
+               return fullScreenEnabled ? true : false;
             }
          };
 


### PR DESCRIPTION
Inside iframes `*RequestFullscreen` function is always enabled, however, if they don't have the `allowfullscreen` attribute, the content can't go in fullscreen.

I've added that check inside the `isSupported` function